### PR TITLE
fix input index for genome file in bcftools call

### DIFF
--- a/workflow/rules/call.smk
+++ b/workflow/rules/call.smk
@@ -23,7 +23,7 @@ rule call:
         expand("{logs}/{{individual}}/mpielup.log", logs=config["log_dir"]),
         expand("{logs}/{{individual}}/call.log", logs=config["log_dir"])
     shell:
-        "bcftools mpileup --threads {threads} -q 20 -Q 20 -Ou -s {wildcards.individual} --ignore-RG -f {input[1]} {input[0]} -a \"AD,ADF,ADR,DP,SP\" 2> {log[0]} | bcftools call --threads {threads} -a \"GQ\" --ploidy {config[ploidy]} -m -Oz -o {output} > {log[1]} 2>&1"
+        "bcftools mpileup --threads {threads} -q 20 -Q 20 -Ou -s {wildcards.individual} --ignore-RG -f {input[2]} {input[0]} -a \"AD,ADF,ADR,DP,SP\" 2> {log[0]} | bcftools call --threads {threads} -a \"GQ\" --ploidy {config[ploidy]} -m -Oz -o {output} > {log[1]} 2>&1"
 
 rule rename_individual:
     input:


### PR DESCRIPTION
Input in `rule call` was incorrect for the changes to getting the bam files.