### PR TITLE
Add missingness filters to configuration and update filtering rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Snakemake pipeline to do variant calling, that is, get from fastq files from the
 
 2. Adjust the paths to the genome in the `config.yml` file.
 
-3. Create a chromosomes file from your reference genome:
+3. Decide on a missingness filter for your individuals by setting `max_missingness_individual` in your `config.yml`. If you are unsure how much missingness to allow, run the pipeline with the option left empty. This will only run until the step `sample.stats` at which point you may investigate missingness in your individuals and decide on an appropriate cutoff.
+
+4. Create a chromosomes file from your reference genome:
 
     ```bash
     samtools faidx <reference.fasta> 
@@ -42,7 +44,7 @@ Snakemake pipeline to do variant calling, that is, get from fastq files from the
 
     And adjust the path in the `config.yml` (or place it in the resources folder)
 
-4. Create a individuals.txt file from your list of fastq files/sample sheet. The individuals.txt file needs to be a tab seperated file with 2 columns, the first one being the individual ids that should be in the final vcf and the second the _path to the raw fastq file and the filename_. Each line should only contain a single fastq file, but an individual can appear in multiple lines. The program automatically figures out R1 and R2 reads, as long as the first read in both files has the same fastq id.
+5. Create a individuals.txt file from your list of fastq files/sample sheet. The individuals.txt file needs to be a tab seperated file with 2 columns, the first one being the individual ids that should be in the final vcf and the second the _path to the raw fastq file and the filename_. Each line should only contain a single fastq file, but an individual can appear in multiple lines. The program automatically figures out R1 and R2 reads, as long as the first read in both files has the same fastq id.
 
     For example:
     

--- a/config.yml.template
+++ b/config.yml.template
@@ -13,5 +13,5 @@ repeat_bed: "resources/repeat.bed"
 consensus_fasta_dir: "results/consensus"
 ploidy: 2
 outgroup_individuals: []
-max_missingness_individual: 0.25
+max_missingness_individual: 
 max_missingness_site: 0.2

--- a/config.yml.template
+++ b/config.yml.template
@@ -13,3 +13,5 @@ repeat_bed: "resources/repeat.bed"
 consensus_fasta_dir: "results/consensus"
 ploidy: 2
 outgroup_individuals: []
+max_missingness_individual: 0.25
+max_missingness_site: 0.2

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - datamash
   - bioconda::bedtools
   - matplotlib
+  - pandas

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -11,11 +11,22 @@ import re
 configfile: "config.yml"
 localrules: all, index_bam, index_reference, parse_json, summarize_fastq_stats, fastq_stats, merge_trimmed, retain_list
 
+
+def output_files():
+    max_missingness_individual = config["max_missingness_individual"]
+    if max_missingness_individual:
+        out = [f'{config["vcf_dir"]}/genome.IF-OG-GF-MM2-RM.vcf.gz',
+                f'{config["vcf_dir"]}/genome.IF-OG-GF-MM2-RM.vcf.gz.csi']
+    else:
+        out = [f"{config['vcf_dir']}/sample.stats"]
+    return out + output_files_qc()
+
+def output_files_qc():
+    return ["results/fastq_stats/runs_fastq_summary"]
+
 rule all:
     input:
-        "results/fastq_stats/runs_fastq_summary",
-        expand('{vcf_dir}/genome.IF-OG-GF-MM2-RM.vcf.gz', vcf_dir = config["vcf_dir"]),
-        expand('{vcf_dir}/genome.IF-OG-GF-MM2-RM.vcf.gz.csi', vcf_dir = config["vcf_dir"])
+        output_files()
 
 rule fastq_stats:
     input:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -13,10 +13,9 @@ localrules: all, index_bam, index_reference, parse_json, summarize_fastq_stats, 
 
 
 def output_files():
-    max_missingness_individual = config["max_missingness_individual"]
-    if max_missingness_individual:
+    if 'max_missingness_individual' in config and config["max_missingness_individual"] is not None:
         out = [f'{config["vcf_dir"]}/genome.IF-OG-GF-MM2-RM.vcf.gz',
-                f'{config["vcf_dir"]}/genome.IF-OG-GF-MM2-RM.vcf.gz.csi']
+               f'{config["vcf_dir"]}/genome.IF-OG-GF-MM2-RM.vcf.gz.csi']
     else:
         out = [f"{config['vcf_dir']}/sample.stats"]
     return out + output_files_qc()

--- a/workflow/rules/filter.smk
+++ b/workflow/rules/filter.smk
@@ -105,7 +105,7 @@ rule sample_stats:
     output:
         expand("{vcf_dir}/sample.stats", vcf_dir = config["vcf_dir"])
     shell:
-        """echo -e "ID\tnREF\tnALT\tnHET\tnTs\tnTv\tavgDP\tSingletons\tMissing_Sites\tMissingness" > {output}
+        """echo -e "ID\tnREF\tnALT\tnHET\tnTs\tnTv\tavgDP\tSingletons\tMissing_Sites\tproportion_Missing" > {output}
         bcftools stats --threads {threads} -S- {input[0]} | grep 'PSC' | grep -v '#' | tr ' ' '_' | awk '{{OFS="\t"}}{{print $3,$4,$5,$6,$7,$8,$10,$11,$14,$14/($4+$5+$6+$14)}}' >> {output}
         """
 
@@ -116,7 +116,7 @@ rule retain_list:
         "results/retain.list"
     run:
         sample_stats = pd.read_csv(input[0], sep='\t')
-        individuals = sample_stats[sample_stats['Missingness'] < config['max_missingness_individual']]
+        individuals = sample_stats[sample_stats['proportion_Missing'] < config['max_missingness_individual']]
         individuals.to_csv(output[0], index=False, header=False, columns=['ID'])
     
 

--- a/workflow/rules/filter.smk
+++ b/workflow/rules/filter.smk
@@ -1,4 +1,5 @@
 import os
+import pandas as pd
 
 def raw_vcf_individual(wildcards):
     vcf_ro = f"{config['ro_ind_vcf_dir']}/{wildcards.individual}.raw.vcf.gz"
@@ -114,11 +115,10 @@ rule retain_list:
     output:
         "results/retain.list"
     run:
-        with open(input[0], 'r') as f:
-            f.readline()
-            individuals = [line.strip().split()[0] for line in f]
-        with open(output[0], 'w') as f:
-            f.write('\n'.join(individuals))        
+        sample_stats = pd.read_csv(input[0], sep='\t')
+        sample_stats['missingness'] = sample_stats['Missing_Sites'] / (sample_stats['nREF'] + sample_stats['nALT'] + sample_stats['nHET'] + sample_stats['Missing_Sites'])
+        individuals = sample_stats[sample_stats['missingness'] < config['max_missingness_individual']]
+        individuals.to_csv(output[0], index=False, header=False, columns=['ID'])
     
 
 rule filter_genotype_missing_ind:
@@ -132,7 +132,7 @@ rule filter_genotype_missing_ind:
         expand("{logs}/filter_genotype_missing_samples.log", logs=config["log_dir"]),
         expand("{logs}/filter_genotype_missing_min.log", logs=config["log_dir"])
     shell:
-        """bcftools view --threads {threads} --samples-file {input[2]} --force-samples -Ou {input[0]} 2> {log[0]} | bcftools view --min-ac 1 --threads {threads} -i 'F_MISSING<0.2' -Oz -o {output} > {log[1]} 2>&1""" 
+        """bcftools view --threads {threads} --samples-file {input[2]} --force-samples -Ou {input[0]} 2> {log[0]} | bcftools view --min-ac 1 --threads {threads} -i 'F_MISSING<{config[max_missingness_site]}' -Oz -o {output} > {log[1]} 2>&1""" 
 
 rule sam_index_reference:
     input:

--- a/workflow/rules/filter.smk
+++ b/workflow/rules/filter.smk
@@ -105,8 +105,8 @@ rule sample_stats:
     output:
         expand("{vcf_dir}/sample.stats", vcf_dir = config["vcf_dir"])
     shell:
-        """echo -e "ID\tnREF\tnALT\tnHET\tnTs\tnTv\tavgDP\tSingletons\tMissing_Sites" > {output}
-        bcftools stats --threads {threads} -S- {input[0]} | grep 'PSC' | tr ' ' '_' | awk '{{OFS="\t"}}{{print $3,$4,$5,$6,$7,$8,$10,$11,$14}}' | sed '1,2d' >> {output}
+        """echo -e "ID\tnREF\tnALT\tnHET\tnTs\tnTv\tavgDP\tSingletons\tMissing_Sites\tMissingness" > {output}
+        bcftools stats --threads {threads} -S- {input[0]} | grep 'PSC' | grep -v '#' | tr ' ' '_' | awk '{{OFS="\t"}}{{print $3,$4,$5,$6,$7,$8,$10,$11,$14,$14/($4+$5+$6+$14)}}' >> {output}
         """
 
 rule retain_list:
@@ -116,8 +116,7 @@ rule retain_list:
         "results/retain.list"
     run:
         sample_stats = pd.read_csv(input[0], sep='\t')
-        sample_stats['missingness'] = sample_stats['Missing_Sites'] / (sample_stats['nREF'] + sample_stats['nALT'] + sample_stats['nHET'] + sample_stats['Missing_Sites'])
-        individuals = sample_stats[sample_stats['missingness'] < config['max_missingness_individual']]
+        individuals = sample_stats[sample_stats['Missingness'] < config['max_missingness_individual']]
         individuals.to_csv(output[0], index=False, header=False, columns=['ID'])
     
 


### PR DESCRIPTION
Closes #33 

Added config options both for filtering individuals out based on missingness, as well as filtering sites out for missingness. If the option for filtering individuals is not passed, the pipeline will stop after creating the sample.stats file so that the user can investigate and decide on a decent cutoff.